### PR TITLE
update lastSuccessfulRefresh even if bundle has same checksum; fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ hs_err_pid*
 /.project
 /.classpath
 /target/
+/.settings/
+/.factorypath

--- a/src/test/java/org/nhindirect/config/BaseTestPlan.java
+++ b/src/test/java/org/nhindirect/config/BaseTestPlan.java
@@ -1,23 +1,7 @@
 package org.nhindirect.config;
 
-import java.io.File;
-
 public abstract class BaseTestPlan
 {	
-	static protected String filePrefix;
-	
-    static
-    {
-
-		// check for Windows... it doens't like file://<drive>... turns it into FTP
-		File file = new File("./src/test/resources/bundles/signedbundle.p7b");
-		if (file.getAbsolutePath().contains(":/"))
-			filePrefix = "file:///";
-		else
-			filePrefix = "file:///";
-    }
-    
-	
 	public void perform() throws Exception 
 	{
 		try 

--- a/src/test/java/org/nhindirect/config/SpringBaseTest.java
+++ b/src/test/java/org/nhindirect/config/SpringBaseTest.java
@@ -31,8 +31,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 @TestPropertySource("classpath:bootstrap.properties")
 public abstract class SpringBaseTest
 {
-	protected String filePrefix;
-	
 	@Autowired
 	protected TestRestTemplate testRestTemplate;
 	
@@ -81,14 +79,6 @@ public abstract class SpringBaseTest
 	@BeforeEach
 	public void setUp()
 	{
-		
-		// check for Windows... it doens't like file://<drive>... turns it into FTP
-		File file = new File("./src/test/resources/bundles/signedbundle.p7b");
-		if (file.getAbsolutePath().contains(":/"))
-			filePrefix = "file:///";
-		else
-			filePrefix = "file:///";
-		
 		try
 		{
 			cleanDataStore();

--- a/src/test/java/org/nhindirect/config/TestUtils.java
+++ b/src/test/java/org/nhindirect/config/TestUtils.java
@@ -1,26 +1,20 @@
 package org.nhindirect.config;
 
-import java.io.File;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 public class TestUtils 
 {
-	private static final String certsBasePath = "src/test/resources/certs/"; 
-	private static final String signerBasePath = "src/test/resources/signers/"; 
-	private static final String bundleBasePath = "src/test/resources/bundles/"; 
+	private static final String certsBasePath = "certs/"; 
+	private static final String signerBasePath = "signers/"; 
+	private static final String bundleBasePath = "bundles/"; 
 	
 	public static byte[] loadBundle(String bundleFileName) throws Exception
 	{
-		File fl = new File(bundleBasePath + bundleFileName);
-		
-		return FileUtils.readFileToByteArray(fl);
-
+		return IOUtils.resourceToByteArray(bundleBasePath + bundleFileName, TestUtils.class.getClassLoader());
 	}
 	
 	public static X509Certificate loadCert(String certFileName) throws Exception
@@ -35,9 +29,7 @@ public class TestUtils
 	
 	protected static final X509Certificate fromFile(String base, String file) throws Exception
 	{
-		File fl = new File(base + file);
-
-		try (final InputStream data = FileUtils.openInputStream(fl))
+		try (final InputStream data = TestUtils.class.getClassLoader().getResourceAsStream(base + file))
 		{
 			X509Certificate retVal = (X509Certificate)CertificateFactory.getInstance("X.509").generateCertificate(data);
 			return retVal;
@@ -46,19 +38,4 @@ public class TestUtils
 		{
 		}
 	}
-	
-    public static final String uriEscape(String val) 
-    {
-        try 
-        {
-            final String escapedVal = URLEncoder.encode(val, "UTF-8");
-            // Spaces are treated differently in actual URLs. There don't appear to be any other
-            // differences...
-            return escapedVal.replace("+", "%20");
-        } 
-        catch (UnsupportedEncodingException e) 
-        {
-            throw new RuntimeException("Failed to encode value: " + val, e);
-        }
-    }
 }

--- a/src/test/java/org/nhindirect/config/processor/impl/DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectionTest.java
+++ b/src/test/java/org/nhindirect/config/processor/impl/DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectionTest.java
@@ -11,9 +11,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.security.cert.X509Certificate;
-import java.util.Calendar;
+import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Locale;
 
 import org.nhindirect.config.TestUtils;
 import org.nhindirect.config.repository.TrustBundleAnchorRepository;
@@ -33,7 +32,7 @@ public class DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectio
 		
 		final TrustBundle existingBundle = new TrustBundle();
 		
-		final Calendar processAttempStart = Calendar.getInstance(Locale.getDefault());
+		final LocalDateTime processAttempStart = LocalDateTime.now();
 		
 		Collection<X509Certificate> anchors = processor.convertRawBundleToAnchorCollection(rawBundle, existingBundle, processAttempStart).block();
 		
@@ -51,7 +50,7 @@ public class DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectio
 		
 		final TrustBundle existingBundle = new TrustBundle();
 		
-		final Calendar processAttempStart = Calendar.getInstance(Locale.getDefault());
+		final LocalDateTime processAttempStart = LocalDateTime.now();
 		
 		Collection<X509Certificate> anchors = processor.convertRawBundleToAnchorCollection(rawBundle, existingBundle, processAttempStart).block();
 		
@@ -72,7 +71,7 @@ public class DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectio
 		final TrustBundle existingBundle = new TrustBundle();
 		existingBundle.setSigningCertificateData(signer.getEncoded());
 		
-		final Calendar processAttempStart = Calendar.getInstance(Locale.getDefault());
+		final LocalDateTime processAttempStart = LocalDateTime.now();
 		
 		Collection<X509Certificate> anchors = processor.convertRawBundleToAnchorCollection(rawBundle, existingBundle, processAttempStart).block();
 		
@@ -100,7 +99,7 @@ public class DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectio
 		final TrustBundle existingBundle = new TrustBundle();
 		existingBundle.setSigningCertificateData(signer.getEncoded());
 		
-		final Calendar processAttempStart = Calendar.getInstance(Locale.getDefault());
+		final LocalDateTime processAttempStart = LocalDateTime.now();
 		
 		Collection<X509Certificate> anchors = processor.convertRawBundleToAnchorCollection(rawBundle, existingBundle, processAttempStart).block();
 		
@@ -122,7 +121,7 @@ public class DefaultBundleRefreshProcessorImpl_convertRawBundleToAnchorCollectio
 		
 		final TrustBundle existingBundle = new TrustBundle();
 		
-		final Calendar processAttempStart = Calendar.getInstance(Locale.getDefault());
+		final LocalDateTime processAttempStart = LocalDateTime.now();
 		
 		Collection<X509Certificate> anchors = processor.convertRawBundleToAnchorCollection(rawBundle, existingBundle, processAttempStart).block();
 		

--- a/src/test/java/org/nhindirect/config/processor/impl/DefaultBundleRefreshProcessorImpl_refreshBundleTest.java
+++ b/src/test/java/org/nhindirect/config/processor/impl/DefaultBundleRefreshProcessorImpl_refreshBundleTest.java
@@ -5,14 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.util.Collection;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.ArgumentMatchers.any;
 
-
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,8 +30,6 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 	protected TrustBundleRepository repo;
 	protected TrustBundleAnchorRepository anchorRepo;
 	
-	protected String filePrefix;
-	
 	@SuppressWarnings("unchecked")
 	@BeforeEach
 	public void setUp()
@@ -44,13 +40,6 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 		when(repo.save(any())).thenReturn(Mono.empty());
 		when(anchorRepo.deleteByTrustBundleId(any())).thenReturn(Mono.empty());
 		when(anchorRepo.saveAll((Collection<TrustBundleAnchor>)any())).thenReturn(Flux.empty());
-		
-		// check for Windows... it doens't like file://<drive>... turns it into FTP
-		File file = new File("./src/test/resources/bundles/signedbundle.p7b");
-		if (file.getAbsolutePath().contains(":/"))
-			filePrefix = "file:///";
-		else
-			filePrefix = "file:///";
 	}
 	
 	@Test
@@ -61,8 +50,8 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 		
 		final TrustBundle bundle = new TrustBundle();
 		bundle.setBundleName("Junit Bundle");
-		File fl = new File("src/test/resources/bundles/signedbundle.p7b");
-		bundle.setBundleURL(filePrefix + fl.getAbsolutePath());
+		String bundleURL = getClass().getClassLoader().getResource("bundles/signedbundle.p7b").toString();
+		bundle.setBundleURL(bundleURL);
 	
 		processor.refreshBundle(bundle).block();
 	
@@ -77,8 +66,8 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 		
 		final TrustBundle bundle = new TrustBundle();
 		bundle.setBundleName("Junit Bundle");
-		File fl = new File("src/test/resources/bundles/signedbundle.p7b");
-		bundle.setBundleURL(filePrefix + fl.getAbsolutePath());
+		String bundleURL = getClass().getClassLoader().getResource("bundles/signedbundle.p7b").toString();
+		bundle.setBundleURL(bundleURL);
 		bundle.setCheckSum("12345");
 	
 		processor.refreshBundle(bundle).block();
@@ -94,12 +83,13 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 		
 		final TrustBundle bundle = new TrustBundle();
 		
-		File fl = new File("src/test/resources/bundles/signedbundle.p7b");
+		String bundleResourceName = "bundles/signedbundle.p7b";
+		String bundleURL = getClass().getClassLoader().getResource(bundleResourceName).toString();
 		
-		byte[] rawBundleByte = FileUtils.readFileToByteArray(fl);
+		byte[] rawBundleByte = IOUtils.resourceToByteArray(bundleResourceName, getClass().getClassLoader());
 		
 		bundle.setBundleName("Junit Bundle");
-		bundle.setBundleURL(filePrefix + fl.getAbsolutePath());
+		bundle.setBundleURL(bundleURL);
 		bundle.setCheckSum(BundleThumbprint.toThumbprint(rawBundleByte).toString());
 		
 		processor.refreshBundle(bundle).block();
@@ -115,8 +105,8 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 		
 		final TrustBundle bundle = new TrustBundle();
 		bundle.setBundleName("Junit Bundle");
-		File fl = new File("src/test/resources/bundles/signedbundle.p7b2122");
-		bundle.setBundleURL(filePrefix + fl.getAbsolutePath());
+		String bundleURL = getClass().getClassLoader().getResource("bundles/signedbundle.p7b").toString();
+		bundle.setBundleURL(bundleURL + "2122");
 	
 		processor.refreshBundle(bundle).block();
 	
@@ -131,8 +121,8 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 		
 		final TrustBundle bundle = new TrustBundle();
 		bundle.setBundleName("Junit Bundle");
-		File fl = new File("src/test/resources/bundles/invalidBundle.der");
-		bundle.setBundleURL(filePrefix + fl.getAbsolutePath());
+		String bundleURL = getClass().getClassLoader().getResource("bundles/invalidBundle.der").toString();
+		bundle.setBundleURL(bundleURL);
 	
 		processor.refreshBundle(bundle).block();
 	
@@ -149,8 +139,8 @@ public class DefaultBundleRefreshProcessorImpl_refreshBundleTest
 			
 			final TrustBundle bundle = new TrustBundle();
 			bundle.setBundleName("Junit Bundle");
-			File fl = new File("src/test/resources/bundles/signedbundle.p7b");
-			bundle.setBundleURL(filePrefix + fl.getAbsolutePath());
+			String bundleURL = getClass().getClassLoader().getResource("bundles/signedbundle.p7b").toString();
+			bundle.setBundleURL(bundleURL);
 		
 			doThrow(new ConfigurationStoreException("Just Passing Through")).when(repo).save((TrustBundle)any());
 	

--- a/src/test/java/org/nhindirect/config/resources/CertificateResource_addCertificateTest.java
+++ b/src/test/java/org/nhindirect/config/resources/CertificateResource_addCertificateTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 
 
-import java.io.File;
 import java.security.cert.X509Certificate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -19,7 +18,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.nhindirect.common.cert.Thumbprint;
 import org.nhindirect.config.BaseTestPlan;
 import org.nhindirect.config.SpringBaseTest;
@@ -280,7 +279,7 @@ public class CertificateResource_addCertificateTest extends SpringBaseTest
 						certs = new ArrayList<Certificate>();
 						
 						Certificate cert = new Certificate();	
-						byte[] keyData = FileUtils.readFileToByteArray(new File("./src/test/resources/certs/gm2552Key.der"));
+						byte[] keyData = IOUtils.resourceToByteArray("certs/gm2552Key.der", getClass().getClassLoader());
 						
 						cert.setData(CertUtils.certAndWrappedKeyToRawByteFormat(keyData, TestUtils.loadCert("gm2552.der")));
 						

--- a/src/test/java/org/nhindirect/config/resources/CertificateResource_getAllCertificatesTest.java
+++ b/src/test/java/org/nhindirect/config/resources/CertificateResource_getAllCertificatesTest.java
@@ -8,14 +8,12 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.apache.commons.io.FileUtils;
-
+import org.apache.commons.io.IOUtils;
 import org.nhindirect.common.cert.Thumbprint;
 import org.nhindirect.config.BaseTestPlan;
 import org.nhindirect.config.SpringBaseTest;
@@ -162,7 +160,7 @@ public class CertificateResource_getAllCertificatesTest extends SpringBaseTest
 						certs = new ArrayList<Certificate>();
 						
 						Certificate cert = new Certificate();	
-						byte[] keyData = FileUtils.readFileToByteArray(new File("./src/test/resources/certs/gm2552Key.der"));
+						byte[] keyData = IOUtils.resourceToByteArray("certs/gm2552Key.der", getClass().getClassLoader());
 						
 						cert.setData(CertUtils.certAndWrappedKeyToRawByteFormat(keyData, TestUtils.loadCert("gm2552.der")));
 						

--- a/src/test/java/org/nhindirect/config/resources/CertificateResource_getCertificatesByOwnerAndThumbprintTest.java
+++ b/src/test/java/org/nhindirect/config/resources/CertificateResource_getCertificatesByOwnerAndThumbprintTest.java
@@ -10,14 +10,12 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.net.URI;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.commons.io.FileUtils;
-
+import org.apache.commons.io.IOUtils;
 import org.nhindirect.common.cert.Thumbprint;
 import org.nhindirect.config.BaseTestPlan;
 import org.nhindirect.config.SpringBaseTest;
@@ -176,7 +174,7 @@ public class CertificateResource_getCertificatesByOwnerAndThumbprintTest extends
 						certs = new ArrayList<Certificate>();
 						
 						Certificate cert = new Certificate();	
-						byte[] keyData = FileUtils.readFileToByteArray(new File("./src/test/resources/certs/gm2552Key.der"));
+						byte[] keyData = IOUtils.resourceToByteArray("certs/gm2552Key.der", getClass().getClassLoader());
 						
 						cert.setData(CertUtils.certAndWrappedKeyToRawByteFormat(keyData, TestUtils.loadCert("gm2552.der")));
 						

--- a/src/test/java/org/nhindirect/config/resources/CertificateResource_getCertificatesByOwnerTest.java
+++ b/src/test/java/org/nhindirect/config/resources/CertificateResource_getCertificatesByOwnerTest.java
@@ -9,12 +9,11 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.nhindirect.common.cert.Thumbprint;
 import org.nhindirect.config.BaseTestPlan;
 import org.nhindirect.config.SpringBaseTest;
@@ -166,7 +165,7 @@ public class CertificateResource_getCertificatesByOwnerTest extends SpringBaseTe
 						certs = new ArrayList<Certificate>();
 						
 						Certificate cert = new Certificate();	
-						byte[] keyData = FileUtils.readFileToByteArray(new File("./src/test/resources/certs/gm2552Key.der"));
+						byte[] keyData = IOUtils.resourceToByteArray("certs/gm2552Key.der", getClass().getClassLoader());
 						
 						cert.setData(CertUtils.certAndWrappedKeyToRawByteFormat(keyData, TestUtils.loadCert("gm2552.der")));
 						

--- a/src/test/java/org/nhindirect/config/resources/CertificateResource_removeCertificatesByIdsTest.java
+++ b/src/test/java/org/nhindirect/config/resources/CertificateResource_removeCertificatesByIdsTest.java
@@ -8,14 +8,12 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
-
+import org.apache.commons.io.IOUtils;
 import org.nhindirect.config.BaseTestPlan;
 import org.nhindirect.config.SpringBaseTest;
 import org.nhindirect.config.TestUtils;
@@ -212,7 +210,7 @@ public class CertificateResource_removeCertificatesByIdsTest extends SpringBaseT
 						certs = new ArrayList<Certificate>();
 						
 						Certificate cert = new Certificate();	
-						byte[] keyData = FileUtils.readFileToByteArray(new File("./src/test/resources/certs/gm2552Key.der"));
+						byte[] keyData = IOUtils.resourceToByteArray("certs/gm2552Key.der", getClass().getClassLoader());
 						
 						cert.setData(CertUtils.certAndWrappedKeyToRawByteFormat(keyData, TestUtils.loadCert("gm2552.der")));
 						

--- a/src/test/java/org/nhindirect/config/resources/CertificateResource_removeCertificatesByOwnerTest.java
+++ b/src/test/java/org/nhindirect/config/resources/CertificateResource_removeCertificatesByOwnerTest.java
@@ -8,11 +8,10 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.nhindirect.config.BaseTestPlan;
 import org.nhindirect.config.SpringBaseTest;
 import org.nhindirect.config.TestUtils;
@@ -137,7 +136,7 @@ public class CertificateResource_removeCertificatesByOwnerTest extends SpringBas
 						certs = new ArrayList<Certificate>();
 						
 						Certificate cert = new Certificate();	
-						byte[] keyData = FileUtils.readFileToByteArray(new File("./src/test/resources/certs/gm2552Key.der"));
+						byte[] keyData = IOUtils.resourceToByteArray("certs/gm2552Key.der", getClass().getClassLoader());
 						
 						cert.setData(CertUtils.certAndWrappedKeyToRawByteFormat(keyData, TestUtils.loadCert("gm2552.der")));
 						

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_addTrustBundleTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_addTrustBundleTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -86,8 +85,8 @@ public class TrustBundleResource_addTrustBundleTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -95,7 +94,7 @@ public class TrustBundleResource_addTrustBundleTest extends SpringBaseTest
 						
 						bundle = new TrustBundle();
 						bundle.setBundleName("testBundle2");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(12);
 						bundle.setSigningCertificateData(null);
 						
@@ -155,8 +154,8 @@ public class TrustBundleResource_addTrustBundleTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -164,7 +163,7 @@ public class TrustBundleResource_addTrustBundleTest extends SpringBaseTest
 						
 						bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(12);
 						bundle.setSigningCertificateData(null);
 						
@@ -231,8 +230,8 @@ public class TrustBundleResource_addTrustBundleTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -298,8 +297,8 @@ public class TrustBundleResource_addTrustBundleTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_associateTrustBundleToDomainTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_associateTrustBundleToDomainTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -124,8 +123,8 @@ public class TrustBundleResource_associateTrustBundleToDomainTest extends Spring
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -203,8 +202,8 @@ public class TrustBundleResource_associateTrustBundleToDomainTest extends Spring
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -292,8 +291,8 @@ public class TrustBundleResource_associateTrustBundleToDomainTest extends Spring
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -361,8 +360,8 @@ public class TrustBundleResource_associateTrustBundleToDomainTest extends Spring
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_deleteBundleTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_deleteBundleTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -93,8 +92,8 @@ public class TrustBundleResource_deleteBundleTest extends SpringBaseTest
 					
 					TrustBundle bundle = new TrustBundle();
 					bundle.setBundleName("testBundle1");
-					File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-					bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+					String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+					bundle.setBundleURL(bundleURL);	
 					bundle.setRefreshInterval(24);
 					bundle.setSigningCertificateData(null);		
 					bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_disassociateTrustBundleFromDomainTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_disassociateTrustBundleFromDomainTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -54,8 +53,8 @@ public class TrustBundleResource_disassociateTrustBundleFromDomainTest extends S
 					
 					TrustBundle bundle = new TrustBundle();
 					bundle.setBundleName("testBundle999");
-					File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-					bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+					String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+					bundle.setBundleURL(bundleURL);	
 					bundle.setRefreshInterval(24);
 					bundle.setSigningCertificateData(null);		
 					bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_disassociateTrustBundleFromDomainsTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_disassociateTrustBundleFromDomainsTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -54,8 +53,8 @@ public class TrustBundleResource_disassociateTrustBundleFromDomainsTest extends 
 					
 					TrustBundle bundle = new TrustBundle();
 					bundle.setBundleName("testBundle1");
-					File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-					bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+					String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+					bundle.setBundleURL(bundleURL);	
 					bundle.setRefreshInterval(24);
 					bundle.setSigningCertificateData(null);		
 					bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_disassociateTrustBundlesFromDomainTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_disassociateTrustBundlesFromDomainTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -54,8 +53,8 @@ public class TrustBundleResource_disassociateTrustBundlesFromDomainTest extends 
 					
 					TrustBundle bundle = new TrustBundle();
 					bundle.setBundleName("testBundle1");
-					File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-					bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+					String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+					bundle.setBundleURL(bundleURL);	
 					bundle.setRefreshInterval(24);
 					bundle.setSigningCertificateData(null);		
 					bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getAllTrustBundleDomainRelts.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getAllTrustBundleDomainRelts.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -137,8 +136,8 @@ public class TrustBundleResource_getAllTrustBundleDomainRelts extends SpringBase
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						
@@ -226,8 +225,8 @@ public class TrustBundleResource_getAllTrustBundleDomainRelts extends SpringBase
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getTrustBundleByNameTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getTrustBundleByNameTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -94,8 +93,8 @@ public class TrustBundleResource_getTrustBundleByNameTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -148,8 +147,8 @@ public class TrustBundleResource_getTrustBundleByNameTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getTrustBundlesByDomainTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getTrustBundlesByDomainTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -142,8 +141,8 @@ public class TrustBundleResource_getTrustBundlesByDomainTest extends SpringBaseT
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						
@@ -238,8 +237,8 @@ public class TrustBundleResource_getTrustBundlesByDomainTest extends SpringBaseT
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getTrustBundlesTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_getTrustBundlesTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -222,8 +221,8 @@ public class TrustBundleResource_getTrustBundlesTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -231,7 +230,7 @@ public class TrustBundleResource_getTrustBundlesTest extends SpringBaseTest
 						
 						bundle = new TrustBundle();
 						bundle.setBundleName("testBundle2");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(12);
 						bundle.setSigningCertificateData(null);
 						
@@ -285,8 +284,8 @@ public class TrustBundleResource_getTrustBundlesTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -294,7 +293,7 @@ public class TrustBundleResource_getTrustBundlesTest extends SpringBaseTest
 						
 						bundle = new TrustBundle();
 						bundle.setBundleName("testBundle2");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(12);
 						bundle.setSigningCertificateData(null);
 						

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_refreshBundleTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_refreshBundleTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -97,8 +96,8 @@ public class TrustBundleResource_refreshBundleTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -141,8 +140,8 @@ public class TrustBundleResource_refreshBundleTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_updateBundleAttributesTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_updateBundleAttributesTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -109,8 +108,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -173,8 +172,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -192,8 +191,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 				{
 					final TrustBundle bundleData = new TrustBundle();
 					bundleData.setBundleName("testBundle1");
-					File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-					bundleData.setBundleURL(filePrefix + fl.getAbsolutePath());	
+					String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+					bundleData.setBundleURL(bundleURL);	
 					bundleData.setRefreshInterval(24);
 					bundleData.setSigningCertificateData(null);	
 					
@@ -241,8 +240,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -306,8 +305,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(TestUtils.loadSigner("bundleSigner.der").getEncoded());		
 						bundles.add(bundle);
@@ -371,8 +370,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(TestUtils.loadSigner("bundleSigner.der").getEncoded());		
 						bundles.add(bundle);
@@ -389,8 +388,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 				protected TrustBundle getBundleDataToUpdate() throws Exception
 				{
 					final TrustBundle bundleData = new TrustBundle();
-					File fl = new File("src/test/resources/bundles/invalidBundle.der");
-					bundleData.setBundleURL(filePrefix + fl.getAbsolutePath());	
+					String bundleURL = getClass().getClassLoader().getResource("bundles/invalidBundle.der").toString();
+					bundleData.setBundleURL(bundleURL);	
 					
 					return bundleData;
 					
@@ -435,8 +434,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -497,8 +496,8 @@ public class TrustBundleResource_updateBundleAttributesTest extends SpringBaseTe
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);

--- a/src/test/java/org/nhindirect/config/resources/TrustBundleResource_updateSigningCertTest.java
+++ b/src/test/java/org/nhindirect/config/resources/TrustBundleResource_updateSigningCertTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -110,8 +109,8 @@ public class TrustBundleResource_updateSigningCertTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(null);		
 						bundles.add(bundle);
@@ -160,8 +159,8 @@ public class TrustBundleResource_updateSigningCertTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(TestUtils.loadSigner("bundleSigner.der").getEncoded());		
 						bundles.add(bundle);
@@ -210,8 +209,8 @@ public class TrustBundleResource_updateSigningCertTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(TestUtils.loadSigner("bundleSigner.der").getEncoded());		
 						bundles.add(bundle);
@@ -262,8 +261,8 @@ public class TrustBundleResource_updateSigningCertTest extends SpringBaseTest
 						
 						TrustBundle bundle = new TrustBundle();
 						bundle.setBundleName("testBundle1");
-						File fl = new File("src/test/resources/bundles/providerTestBundle.p7b");
-						bundle.setBundleURL(filePrefix + fl.getAbsolutePath());	
+						String bundleURL = getClass().getClassLoader().getResource("bundles/providerTestBundle.p7b").toString();
+						bundle.setBundleURL(bundleURL);	
 						bundle.setRefreshInterval(24);
 						bundle.setSigningCertificateData(TestUtils.loadSigner("bundleSigner.der").getEncoded());		
 						bundles.add(bundle);


### PR DESCRIPTION
"Connection reset by peer" errors when downloading trust bundles; fix
"URISyntaxException: Illegal character in path" in unit tests